### PR TITLE
Update to use [] and [:] syntax for Array<> and Dictionary<>

### DIFF
--- a/DataSource/ArrayExtensions.swift
+++ b/DataSource/ArrayExtensions.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Array {
     /// Transforms an array into typed data source rows
-    public func toDataSourceRows(rowIdentifier: String) -> Array<Row<Element>> {
+    public func toDataSourceRows(rowIdentifier: String) -> [Row<Element>] {
         return self.map { item in Row(identifier: rowIdentifier, data: item) }
     }
     

--- a/DataSource/DataSource.swift
+++ b/DataSource/DataSource.swift
@@ -66,7 +66,7 @@ public struct Row<T>: RowType {
 */
 public struct Section<T>: SectionType {
     /// Array of typed rows
-    public let rows: Array<Row<T>>
+    public let rows: [Row<T>]
     
     /// Title of the section
     public let title: String?
@@ -86,7 +86,7 @@ public struct Section<T>: SectionType {
     }
     
     /// Initializes a section with an array of rows and an optional title
-    public init(title: String? = nil, rows: Array<Row<T>>) {
+    public init(title: String? = nil, rows: [Row<T>]) {
         self.rows = rows
         self.title = title
         self.rowCreatorClosure = nil
@@ -94,7 +94,7 @@ public struct Section<T>: SectionType {
     }
     
     /// Initializes a section with an array of models (or view models) which are encapsulated in rows using the specified row identifier
-    public init(title: String? = nil, rowIdentifier: String, rows: Array<T>) {
+    public init(title: String? = nil, rowIdentifier: String, rows: [T]) {
         self.init(title: title, rows: rows.toDataSourceRows(rowIdentifier))
     }
     
@@ -149,7 +149,7 @@ public struct Section<T>: SectionType {
 */
 public struct DataSource: DataSourceType {
     /// Array of sections
-    var sections: Array<SectionType>
+    var sections: [SectionType]
     
     /// Initializes an empty data source (no sections)
     public init() {
@@ -162,12 +162,12 @@ public struct DataSource: DataSourceType {
     }
     
     /// Initializes a data source with multiple sections
-    public init(_ sections: Array<SectionType>) {
+    public init(_ sections: [SectionType]) {
         self.sections = sections
     }
     
     /// Initializes a data source with multiple other data sources by concatinating their sections
-    public init(dataSources: Array<DataSource>) {
+    public init(dataSources: [DataSource]) {
         self.init()
         
         for dataSource in dataSources {

--- a/DataSource/DictionaryExtensions.swift
+++ b/DataSource/DictionaryExtensions.swift
@@ -15,7 +15,7 @@ extension Dictionary where Key: Any, Value: CollectionType {
         Because dictionaries are unordered, it's required to provide an array of ordered keys as well.
         Omitted keys will not be added to the data source.
      */
-    public func toDataSource(rowIdentifier: String, orderedKeys: Array<Key>) -> DataSource {
+    public func toDataSource(rowIdentifier: String, orderedKeys: [Key]) -> DataSource {
         var dataSource = DataSource()
 
         for key in orderedKeys {

--- a/DataSource/TableViewDataSource.swift
+++ b/DataSource/TableViewDataSource.swift
@@ -22,7 +22,7 @@ public class TableViewDataSource: NSObject {
     /// Whether to show section titles
     public var showSectionTitles: Bool?
     
-    var configurators = Dictionary<String, TableViewCellConfiguratorType>()
+    var configurators = [String: TableViewCellConfiguratorType]()
     
     /// Initializes the table view data source with a single cell configurator
     public init(dataSource: DataSource, configurator: TableViewCellConfiguratorType) {
@@ -31,7 +31,7 @@ public class TableViewDataSource: NSObject {
     }
     
     /// Initializes the table view data source with multiple cell configurators
-    public init(dataSource: DataSource, configurators: Array<TableViewCellConfiguratorType>) {
+    public init(dataSource: DataSource, configurators: [TableViewCellConfiguratorType]) {
         self.dataSource = dataSource
         
         for configurator in configurators {

--- a/Example/ExampleTableViewController.swift
+++ b/Example/ExampleTableViewController.swift
@@ -183,7 +183,7 @@ class ExampleTableViewController: UITableViewController {
                 Person(firstName: "Hugo", lastName: "Maier"),
                 Person(firstName: "Max", lastName: "Mustermann"),
                 ]),
-            Section(title: "Empty Section", rowIdentifier: Identifiers.TextCell.rawValue, rows: Array<String>()),
+            Section(title: "Empty Section", rowIdentifier: Identifiers.TextCell.rawValue, rows: [String]()),
             Section(title: "Strings", rowIdentifier: Identifiers.TextCell.rawValue, rows: ["some text", "another text"]),
             ])
         


### PR DESCRIPTION
This PR updates the project to use `[]` and `[:]` syntax instead of  `Array<>` and `Dictionary<>` to increase readability.
