### PR TITLE
Fix - TrailingSwipeAction + SeparatedSection (index out of range bug)

### DIFF
--- a/DataSource.xcodeproj/project.pbxproj
+++ b/DataSource.xcodeproj/project.pbxproj
@@ -721,6 +721,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.buchetics.DataSourceExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -742,6 +743,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.buchetics.DataSourceExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/DataSource/DataSource+UITableViewDelegate.swift
+++ b/DataSource/DataSource+UITableViewDelegate.swift
@@ -474,7 +474,7 @@ extension DataSource {
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let cellDescriptor = self.cellDescriptor(at: indexPath) as? CellDescriptorTypeiOS11
         if let closure = cellDescriptor?.trailingSwipeActionsClosure {
-            return closure(row(at: indexPath), indexPath)
+            return closure(visibleRow(at: indexPath), indexPath)
         } else {
             return fallbackDelegate?.tableView?(tableView, trailingSwipeActionsConfigurationForRowAt: indexPath)
         }
@@ -483,7 +483,7 @@ extension DataSource {
     public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let cellDescriptor = self.cellDescriptor(at: indexPath) as? CellDescriptorTypeiOS11
         if let closure = cellDescriptor?.leadingSwipeActionsClosure {
-            return closure(row(at: indexPath), indexPath)
+            return closure(visibleRow(at: indexPath), indexPath)
         } else {
             return fallbackDelegate?.tableView?(tableView, leadingSwipeActionsConfigurationForRowAt: indexPath)
         }

--- a/Example/ViewControllers/SeparatedSectionViewController.swift
+++ b/Example/ViewControllers/SeparatedSectionViewController.swift
@@ -21,7 +21,18 @@ class SeparatedSectionViewController: UIViewController {
                 CellDescriptor<DiffItem, TitleCell>()
                     .configure { (item, cell, indexPath) in
                         cell.textLabel?.text = item.text
-                },
+                    }
+                    .canEdit { [weak self] (_, _) -> Bool in
+                        return true
+                    }
+                    .trailingSwipeAction { [weak self] (_, _) -> UISwipeActionsConfiguration? in
+                        return UISwipeActionsConfiguration(actions: [
+                            UIContextualAction(style: .destructive, title: "TestAction", handler: { [weak self] (_, _, callback) in
+
+                                callback(true)
+                            })
+                        ])
+                    },
                 CellDescriptor<ColorItem, TitleCell>()
                     .configure { (item, cell, indexPath) in
                         cell.textLabel?.text = item.text


### PR DESCRIPTION
Use the visibleRow function instead of rows function swipeAction delegate functions.

**Old:**
_return closure(row(at: indexPath), indexPath)_

**New:**
_return closure(visibleRow(at: indexPath), indexPath)_

**Example:**
Add an example in the SeparatedSectionViewController and increase the target version for the Example project to iOS 11.

Fixed #28 